### PR TITLE
CGBA-74 Enable users to inject messages by X-Message-Sender or by balance ID

### DIFF
--- a/app/connectors/TraderRouterConnector.scala
+++ b/app/connectors/TraderRouterConnector.scala
@@ -54,7 +54,7 @@ class TraderRouterConnectorImpl @Inject() (
 
     val headers = Seq(
       HeaderNames.CONTENT_TYPE -> MimeTypes.XML,
-      "X-Message-Recipient"    -> recipient.value,
+      "X-Message-Recipient"    -> recipient.messageIdValue,
       "X-Message-Type"         -> messageType.code
     )
 

--- a/app/models/SimulatedResponse.scala
+++ b/app/models/SimulatedResponse.scala
@@ -18,9 +18,9 @@ package models
 
 import models.values.GuaranteeReference
 import models.values.TaxIdentifier
+import models.values.UniqueReference
 import play.api.libs.json.Json
 import play.api.libs.json.OFormat
-import models.values.UniqueReference
 
 case class SimulatedResponse(
   taxIdentifier: TaxIdentifier,

--- a/app/models/values/MessageRecipient.scala
+++ b/app/models/values/MessageRecipient.scala
@@ -38,14 +38,7 @@ object MessageRecipient extends Logging {
   val MessageIdRegex = """MDTP-GUA-[0-9a-fA-F]{24}""".r
 
   implicit val messageIdentifierRecipientPathBindable: PathBindable[MessageIdRecipient] =
-    new PathBindable.Parsing[MessageIdRecipient](
-      MessageIdRecipient.apply,
-      _.value,
-      (key, exc) => {
-        logger.warn("Unable to parse message identifier value", exc)
-        s"Cannot parse parameter $key as a message identifier value"
-      }
-    )
+    PathBindable.bindableString.transform(MessageIdRecipient.apply, _.value)
 
   implicit val balanceIdRecipientPathBindable: PathBindable[BalanceIdRecipient] =
     PathBindable.bindableUUID.transform(BalanceIdRecipient.apply, _.value)

--- a/app/models/values/MessageRecipient.scala
+++ b/app/models/values/MessageRecipient.scala
@@ -16,12 +16,56 @@
 
 package models.values
 
-import play.api.libs.json.Format
-import play.api.libs.json.Json
+import play.api.Logging
+import play.api.mvc.PathBindable
 
-case class MessageRecipient(value: String) extends AnyVal
+import java.util.UUID
 
-object MessageRecipient {
-  implicit val messageRecipientFormat: Format[MessageRecipient] =
-    Json.valueFormat[MessageRecipient]
+sealed abstract class MessageRecipient extends Product with Serializable {
+  def messageIdValue: String = this match {
+    case MessageIdRecipient(value) =>
+      value
+    case BalanceIdRecipient(uuid) =>
+      "MDTP-GUA-" + uuid.toString.replaceAll("-", "").take(24)
+  }
+}
+
+case class MessageIdRecipient(value: String) extends MessageRecipient
+
+case class BalanceIdRecipient(value: UUID) extends MessageRecipient
+
+object MessageRecipient extends Logging {
+  val MessageIdRegex = """MDTP-GUA-[0-9a-fA-F]{24}""".r
+
+  implicit val messageIdentifierRecipientPathBindable: PathBindable[MessageIdRecipient] =
+    new PathBindable.Parsing[MessageIdRecipient](
+      MessageIdRecipient.apply,
+      _.value,
+      (key, exc) => {
+        logger.warn("Unable to parse message identifier value", exc)
+        s"Cannot parse parameter $key as a message identifier value"
+      }
+    )
+
+  implicit val balanceIdRecipientPathBindable: PathBindable[BalanceIdRecipient] =
+    PathBindable.bindableUUID.transform(BalanceIdRecipient.apply, _.value)
+
+  implicit val messageRecipientPathBindable: PathBindable[MessageRecipient] =
+    new PathBindable[MessageRecipient] {
+      override def bind(key: String, value: String): Either[String, MessageRecipient] =
+        value match {
+          case MessageIdRegex() =>
+            messageIdentifierRecipientPathBindable.bind(key, value)
+          case _ =>
+            balanceIdRecipientPathBindable.bind(key, value)
+        }
+
+      override def unbind(key: String, value: MessageRecipient): String =
+        value match {
+          case balanceId @ BalanceIdRecipient(_) =>
+            balanceIdRecipientPathBindable.unbind(key, balanceId)
+          case messageId @ MessageIdRecipient(_) =>
+            messageIdentifierRecipientPathBindable.unbind(key, messageId)
+        }
+    }
 }

--- a/app/services/XmlFormattingService.scala
+++ b/app/services/XmlFormattingService.scala
@@ -75,7 +75,7 @@ class XmlFormattingService @Inject() (clock: Clock, random: Random) {
       <SynIdeMES1>UNOC</SynIdeMES1>
       <SynVerNumMES2>3</SynVerNumMES2>
       <MesSenMES3>NTA.GB</MesSenMES3>
-      <MesRecMES6>{recipient.value}</MesRecMES6>
+      <MesRecMES6>{recipient.messageIdValue}</MesRecMES6>
       <DatOfPreMES9>{dateFormatter.format(dateTime)}</DatOfPreMES9>
       <TimOfPreMES10>{timeFormatter.format(dateTime)}</TimOfPreMES10>
       <IntConRefMES11>{uniqueRef}</IntConRefMES11>
@@ -116,7 +116,7 @@ class XmlFormattingService @Inject() (clock: Clock, random: Random) {
       <SynIdeMES1>UNOC</SynIdeMES1>
       <SynVerNumMES2>3</SynVerNumMES2>
       <MesSenMES3>NTA.GB</MesSenMES3>
-      <MesRecMES6>{recipient.value}</MesRecMES6>
+      <MesRecMES6>{recipient.messageIdValue}</MesRecMES6>
       <DatOfPreMES9>{dateFormatter.format(dateTime)}</DatOfPreMES9>
       <TimOfPreMES10>{timeFormatter.format(dateTime)}</TimOfPreMES10>
       <IntConRefMES11>{uniqueRef}</IntConRefMES11>
@@ -146,7 +146,7 @@ class XmlFormattingService @Inject() (clock: Clock, random: Random) {
       <SynIdeMES1>UNOC</SynIdeMES1>
       <SynVerNumMES2>3</SynVerNumMES2>
       <MesSenMES3>NTA.GB</MesSenMES3>
-      <MesRecMES6>{recipient.value}</MesRecMES6>
+      <MesRecMES6>{recipient.messageIdValue}</MesRecMES6>
       <DatOfPreMES9>{dateFormatter.format(dateTime)}</DatOfPreMES9>
       <TimOfPreMES10>{timeFormatter.format(dateTime)}</TimOfPreMES10>
       <IntConRefMES11>{uniqueRef}</IntConRefMES11>

--- a/test/controllers/TestMessagesControllerSpec.scala
+++ b/test/controllers/TestMessagesControllerSpec.scala
@@ -23,8 +23,9 @@ import models.BalanceRequestSuccess
 import models.SimulatedResponse
 import models.values.CurrencyCode
 import models.values.GuaranteeReference
-import models.values.MessageRecipient
+import models.values.MessageIdRecipient
 import models.values.TaxIdentifier
+import models.values.UniqueReference
 import org.scalacheck.Gen
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
@@ -38,7 +39,6 @@ import uk.gov.hmrc.http.HttpResponse
 
 import java.security.SecureRandom
 import java.time.Clock
-import models.values.UniqueReference
 
 class TestMessagesControllerSpec
     extends AnyFlatSpec
@@ -67,7 +67,7 @@ class TestMessagesControllerSpec
     )
   )
 
-  val messageRecipient = MessageRecipient("MDTP-GUA-22b9899e24ee48e6a18997d1")
+  val messageRecipient = MessageIdRecipient("MDTP-GUA-22b9899e24ee48e6a18997d1")
 
   val simulatedResponse = SimulatedResponse(
     TaxIdentifier("GB12345678900"),

--- a/test/models/MessageIdentifierSpec.scala
+++ b/test/models/MessageIdentifierSpec.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.values
+
+import org.scalacheck.Gen
+import org.scalatest.EitherValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import play.api.mvc.PathBindable
+
+import java.util.UUID
+
+class MessageRecipientSpec
+    extends AnyFlatSpec
+    with Matchers
+    with EitherValues
+    with ScalaCheckPropertyChecks {
+
+  val binder = implicitly[PathBindable[MessageRecipient]]
+
+  val validMessageIdRecipientGen = Gen.stringOfN(24, Gen.hexChar).map("MDTP-GUA-" + _)
+  val validBalanceIdRecipientGen = Gen.uuid.map(_.toString)
+
+  "MessageRecipient" should "be usable as a path parameter when given valid message ID input" in forAll(
+    validMessageIdRecipientGen
+  ) { id =>
+    binder.bind("recipient", id) shouldBe Right(MessageIdRecipient(id))
+  }
+
+  it should "be usable as a path parameter when given valid balance ID input" in forAll(
+    validBalanceIdRecipientGen
+  ) { id =>
+    binder.bind("recipient", id) shouldBe Right(BalanceIdRecipient(UUID.fromString(id)))
+  }
+
+  it should "return an error when given input missing the message sender prefix" in {
+    binder.bind("recipient", "22b9899e24ee48e6a18997d1") shouldBe Left(
+      "Cannot parse parameter recipient as UUID: Invalid UUID string: 22b9899e24ee48e6a18997d1"
+    )
+  }
+
+  it should "return an error when given input containing invalid characters" in {
+    binder.bind("recipient", "MDTP-GUA-X2b9899e24ee48e6a18997d1") shouldBe Left(
+      "Cannot parse parameter recipient as UUID: Invalid UUID string: MDTP-GUA-X2b9899e24ee48e6a18997d1"
+    )
+  }
+
+  it should "return an error when given input that looks like an arrivals identifier" in {
+    binder.bind("recipient", "MDTP-ARR-00000000000000000000001-01") shouldBe Left(
+      "Cannot parse parameter recipient as UUID: Invalid UUID string: MDTP-ARR-00000000000000000000001-01"
+    )
+  }
+
+  it should "return an error when given input that looks like a departures identifier" in {
+    binder.bind("recipient", "MDTP-DEP-00000000000000000000001-01") shouldBe Left(
+      "Cannot parse parameter recipient as UUID: Invalid UUID string: MDTP-DEP-00000000000000000000001-01"
+    )
+  }
+}

--- a/test/services/XmlFormattingServiceSpec.scala
+++ b/test/services/XmlFormattingServiceSpec.scala
@@ -27,8 +27,9 @@ import models.errors.XmlError
 import models.values.CurrencyCode
 import models.values.ErrorType
 import models.values.GuaranteeReference
-import models.values.MessageRecipient
+import models.values.MessageIdRecipient
 import models.values.TaxIdentifier
+import models.values.UniqueReference
 import org.scalatest.StreamlinedXmlEquality
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -38,13 +39,12 @@ import java.time.LocalDateTime
 import java.time.ZoneOffset
 import java.util.Random
 import scala.xml.Utility
-import models.values.UniqueReference
 
 class XmlFormattingServiceSpec extends AsyncFlatSpec with Matchers with StreamlinedXmlEquality {
   val dateTime = LocalDateTime.of(2021, 9, 7, 15, 53, 16).toInstant(ZoneOffset.UTC)
   def service  = new XmlFormattingService(Clock.fixed(dateTime, ZoneOffset.UTC), new Random(0))
 
-  val recipient = MessageRecipient("MDTP-GUA-22b9899e24ee48e6a18997d1")
+  val recipient = MessageIdRecipient("MDTP-GUA-22b9899e24ee48e6a18997d1")
 
   "XmlFormattingService" should "format successful response with correct guarantee type for guarantee reference with voucher code" in {
     val simulatedResponse = SimulatedResponse(


### PR DESCRIPTION
This is to support changes in hmrc/transits-movements-trader-at-departure-stub#42.

In that PR the ability to trigger messages using access code in stubbed environments was added.

To simulate a timeout access codes ending in `000` can be used. 

However, the user needs a way to trigger async messages and they will only have a balance ID, where the transit-movements-trader-eis-router has an abbreviated X-Message-Sender value.

This PR changes the code so that both values can be accepted by the `injectEISResponse` endpoint.