### PR TITLE
CGBA-74 Make original message reference optional

### DIFF
--- a/app/models/SimulatedResponse.scala
+++ b/app/models/SimulatedResponse.scala
@@ -25,7 +25,7 @@ import play.api.libs.json.OFormat
 case class SimulatedResponse(
   taxIdentifier: TaxIdentifier,
   guaranteeReference: GuaranteeReference,
-  originalMessageReference: UniqueReference,
+  originalMessageReference: Option[UniqueReference],
   response: BalanceRequestResponse
 )
 

--- a/test/controllers/TestMessagesControllerSpec.scala
+++ b/test/controllers/TestMessagesControllerSpec.scala
@@ -72,7 +72,7 @@ class TestMessagesControllerSpec
   val simulatedResponse = SimulatedResponse(
     TaxIdentifier("GB12345678900"),
     GuaranteeReference("05DE3300BE0001067A001017"),
-    UniqueReference("7acb933dbe7039"),
+    Some(UniqueReference("7acb933dbe7039")),
     BalanceRequestSuccess(BigDecimal("12345678.90"), CurrencyCode("GBP"))
   )
 


### PR DESCRIPTION
This field is used by the departures stub for realism I guess but it's not really necessary