### PR TITLE
CGBA-90 Implement basic RAML & allow callers to provide XML messages

### DIFF
--- a/app/controllers/TestMessagesController.scala
+++ b/app/controllers/TestMessagesController.scala
@@ -16,19 +16,30 @@
 
 package controllers
 
+import cats.effect.IO
 import cats.effect.unsafe.IORuntime
+import cats.syntax.all._
+import com.fasterxml.jackson.core.JsonParseException
 import connectors.TraderRouterConnector
 import controllers.actions.IOActions
 import models.MessageType
 import models.SimulatedResponse
+import models.errors.JsonParsingError
 import models.values.MessageRecipient
+import org.xml.sax.SAXParseException
+import play.api.http.MimeTypes
+import play.api.i18n.I18nSupport
+import play.api.libs.json._
 import play.api.mvc.ControllerComponents
+import play.api.mvc.Request
+import play.api.mvc.Result
 import services.XmlFormattingService
 import uk.gov.hmrc.http.HttpResponse
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
 import javax.inject.Inject
 import javax.inject.Singleton
+import scala.xml.NodeSeq
 
 @Singleton
 class TestMessagesController @Inject() (
@@ -37,23 +48,73 @@ class TestMessagesController @Inject() (
   cc: ControllerComponents,
   val runtime: IORuntime
 ) extends BackendController(cc)
-    with IOActions {
+    with IOActions
+    with I18nSupport {
+
+  def validateJsonRequest(
+    continue: SimulatedResponse => IO[Result]
+  )(implicit request: Request[String]): IO[Result] = {
+    val validateJson = for {
+      json <- IO(Json.parse(request.body))
+      result <- IO(json.validate[SimulatedResponse]).flatMap {
+        case JsSuccess(simulatedResponse, _) =>
+          continue(simulatedResponse)
+        case JsError(errors) =>
+          val parsingError = JsonParsingError(errors = errors)
+          IO.pure(BadRequest(Json.toJson(parsingError)))
+      }
+    } yield result
+
+    validateJson.recover { case exc: JsonParseException =>
+      BadRequest("Invalid Json: " + exc.getMessage())
+    }
+  }
+
+  def validateXmlRequest(
+    continue: NodeSeq => IO[Result]
+  )(implicit request: Request[String]): IO[Result] = {
+    val validateXml = for {
+      xml    <- IO(scala.xml.XML.loadString(request.body))
+      result <- continue(xml)
+    } yield result
+
+    validateXml.recover { case exc: SAXParseException =>
+      BadRequest("Invalid XML: " + exc.getMessage())
+    }
+  }
+
+  def responseToResult(response: HttpResponse): Result = response match {
+    case HttpResponse(status, body, responseHeaders) =>
+      val headers = responseHeaders.toSeq.flatMap { case (headerName, headerValues) =>
+        headerValues.map { headerValue =>
+          headerName -> headerValue
+        }
+      }
+
+      Status(status)(body).withHeaders(headers: _*)
+  }
 
   def injectEisResponse(recipient: MessageRecipient) =
-    Action.io(parse.json[SimulatedResponse]) { implicit request =>
-      for {
-        message <- formatter.formatMessage(recipient, request.body)
-        messageType = MessageType.forBalanceResponse(request.body.response)
-        response <- connector.injectEisResponse(recipient, messageType, message)
-      } yield response match {
-        case HttpResponse(status, body, responseHeaders) =>
-          val headers = responseHeaders.flatMap { case (headerName, headerValues) =>
-            headerValues.headOption.map { headerValue =>
-              headerName -> headerValue
-            }
+    Action.io(parse.tolerantText) { implicit request =>
+      request.contentType match {
+        case Some(MimeTypes.JSON) =>
+          validateJsonRequest { simulatedResponse =>
+            for {
+              message <- formatter.formatMessage(recipient, simulatedResponse)
+              messageType = MessageType.forBalanceResponse(simulatedResponse.response)
+              response <- connector.injectEisResponse(recipient, messageType, message)
+            } yield responseToResult(response)
           }
 
-          Status(status)(body).withHeaders(headers.toSeq: _*)
+        case Some(MimeTypes.XML) =>
+          validateXmlRequest { message =>
+            connector
+              .injectEisResponse(recipient, MessageType.ResponseQueryOnGuarantees, message)
+              .map(responseToResult)
+          }
+
+        case _ =>
+          IO.pure(UnsupportedMediaType)
       }
     }
 }

--- a/app/models/errors/JsonParsingError.scala
+++ b/app/models/errors/JsonParsingError.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.errors
+
+import play.api.i18n.Messages
+import play.api.libs.json.JsPath
+import play.api.libs.json.Json
+import play.api.libs.json.JsonValidationError
+import play.api.libs.json.OWrites
+
+case class JsonParsingError(
+  message: String = "Invalid request JSON",
+  errors: Seq[(JsPath, Seq[JsonValidationError])]
+)
+
+object JsonParsingError {
+  private def toJsonPath(path: JsPath) =
+    path.path.foldLeft("$")((root, next) => root + next.toJsonString)
+
+  implicit def jsonParsingErrorWrites(implicit messages: Messages): OWrites[JsonParsingError] =
+    OWrites { error =>
+      Json.obj(
+        "code"    -> "INVALID_REQUEST_JSON",
+        "message" -> error.message,
+        "errors" -> error.errors.foldLeft(Json.obj()) { case (obj, (path, errors)) =>
+          obj ++ Json.obj(toJsonPath(path) -> errors.map { error =>
+            messages(error.message, error.args: _*)
+          })
+        }
+      )
+    }
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,2 +1,5 @@
 # microservice specific routes
 POST    /balances/:recipient    controllers.TestMessagesController.injectEisResponse(recipient: MessageRecipient)
+
+GET     /api/definition   controllers.Assets.at(path="/public/api", file="definition.json")
+GET     /api/conf/*file   controllers.Assets.at(path="/public/api/conf", file)

--- a/public/api/conf/1.0/application.raml
+++ b/public/api/conf/1.0/application.raml
@@ -1,0 +1,73 @@
+#%RAML 1.0
+---
+title: CTC Guarantee Balance Test Support
+description: The test support API to allow traders to trigger responses to Common Transit Convention guarantee balance enquiries
+protocols: [ HTTPS ]
+baseUri: https://api.service.hmrc.gov.uk/
+version: 1.0
+
+documentation:
+ - title: Overview
+   content: !include docs/overview.md
+ - title: Versioning
+   content: !include https://developer.service.hmrc.gov.uk/api-documentation/assets/common/docs/versioning.md
+
+mediaType: [ application/json ]
+
+uses:
+  sec: https://developer.service.hmrc.gov.uk/api-documentation/assets/common/modules/securitySchemes.raml
+  headers: https://developer.service.hmrc.gov.uk/api-documentation/assets/common/modules/headers.raml
+  annotations: https://developer.service.hmrc.gov.uk/api-documentation/assets/common/modules/annotations.raml
+  types: https://developer.service.hmrc.gov.uk/api-documentation/assets/common/modules/types.raml
+
+/test/customs/guarantees/balances/{balanceId}:
+  uriParameters:
+    balanceId:
+      description: The balance ID or message recipient ID of the balance request for which a response is being triggered.
+      type: string
+      example: "22b9899e-24ee-48e6-a189-97d1f45391c4"
+      required: true
+
+  post:
+    displayName: Trigger a Balance Request Response
+    is:
+      - headers.contentHeader
+    (annotations.scope): "common-transit-convention-guarantee-balance-test-support"
+    securedBy: [ sec.oauth_2_0: { scopes: [ "common-transit-convention-guarantee-balance-test-support" ] } ]
+    body:
+      application/json:
+        type: !include schemas/simulated-balance-response-schema.json
+        example: |
+          {
+            "taxIdentifier": "GB123456789012",
+            "guaranteeReference": "20GB0000010000GX1",
+            "response": {
+                "status": "SUCCESS",
+                "balance": 12345678.9,
+                "currency": "EUR"
+            }
+          }
+    responses:
+      200:
+      400:
+        body:
+          application/json:
+            type: types.errorResponse
+            examples:
+              badRequest:
+                description: The response data was unable to be parsed
+                value:
+                  code: BAD_REQUEST
+              schemaValidation:
+                description: The response did not satisfy the XML schema
+                value:
+                  code: SCHEMA_VALIDATION
+      404:
+        body:
+          application/json:
+            type: types.errorResponse
+            examples:
+              badRequest:
+                description: The balance request was not found
+                value:
+                  code: NOT_FOUND

--- a/public/api/conf/1.0/application.raml
+++ b/public/api/conf/1.0/application.raml
@@ -20,6 +20,16 @@ uses:
   annotations: https://developer.service.hmrc.gov.uk/api-documentation/assets/common/modules/annotations.raml
   types: https://developer.service.hmrc.gov.uk/api-documentation/assets/common/modules/types.raml
 
+
+traits:
+  contentHeader:
+    headers:
+      Content-Type:
+        description: Specifies the format of the request body, which must be either JSON or XML.
+        type: string
+        required: true
+        example: application/json
+
 /test/customs/guarantees/balances/{balanceId}:
   uriParameters:
     balanceId:
@@ -31,7 +41,7 @@ uses:
   post:
     displayName: Trigger a Balance Request Response
     is:
-      - headers.contentHeader
+      - contentHeader
     (annotations.scope): "common-transit-convention-guarantee-balance-test-support"
     securedBy: [ sec.oauth_2_0: { scopes: [ "common-transit-convention-guarantee-balance-test-support" ] } ]
     body:
@@ -47,6 +57,41 @@ uses:
                 "currency": "EUR"
             }
           }
+      application/xml:
+        example: |
+          <CD037A>
+            <SynIdeMES1>UNOC</SynIdeMES1>
+            <SynVerNumMES2>3</SynVerNumMES2>
+            <MesSenMES3>NTA.GB</MesSenMES3>
+            <MesRecMES6>MDTP-GUA-22b9899e24ee48e6a18997d1</MesRecMES6>
+            <DatOfPreMES9>20210806</DatOfPreMES9>
+            <TimOfPreMES10>1505</TimOfPreMES10>
+            <IntConRefMES11>deadbeefcafeba</IntConRefMES11>
+            <MesIdeMES19>deadbeefcafeba</MesIdeMES19>
+            <MesTypMES20>GB037A</MesTypMES20>
+            <TRAPRIRC1>
+              <TINRC159>GB12345678900</TINRC159>
+            </TRAPRIRC1>
+            <CUSTOFFGUARNT>
+              <RefNumRNT1>GB000001</RefNumRNT1>
+            </CUSTOFFGUARNT>
+            <GUAREF2>
+              <GuaRefNumGRNREF21>21GB3300BE0001067A001017</GuaRefNumGRNREF21>
+              <AccDatREF24>20210114</AccDatREF24>
+              <GuaTypREF22>4</GuaTypREF22>
+              <GuaMonCodREF23>1</GuaMonCodREF23>
+              <GUAQUE>
+                <QueIdeQUE1>2</QueIdeQUE1>
+              </GUAQUE>
+              <EXPEXP>
+                <ExpEXP1>2751.95</ExpEXP1>
+                <ExpCouEXP2>2448</ExpCouEXP2>
+                <BalEXP3>1212211848.45</BalEXP3>
+                <CurEXP4>GBP</CurEXP4>
+              </EXPEXP>
+            </GUAREF2>
+          </CD037A>
+
     responses:
       200:
       400:

--- a/public/api/conf/1.0/docs/overview.md
+++ b/public/api/conf/1.0/docs/overview.md
@@ -1,0 +1,1 @@
+This API allows testers to inject guarantee query responses as if they have come from the office of guarantee by the New Computerised Transit System (NCTS).

--- a/public/api/conf/1.0/schemas/simulated-balance-response-schema.json
+++ b/public/api/conf/1.0/schemas/simulated-balance-response-schema.json
@@ -1,0 +1,29 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$id": "#/simulated-balance-response-schema.json",
+    "description": "A simulated response from the guarantee management system",
+    "type": "object",
+    "required": [
+        "taxIdentifier",
+        "guaranteeReference",
+        "response"
+    ],
+    "properties": {
+        "taxIdentifier": {
+            "type": "string",
+            "description": "The tax identifier of the holder of the guarantee"
+        },
+        "guaranteeReference": {
+            "type": "string",
+            "description": "The guarantee reference number (GRN) of the guarantee"
+        },
+        "originalMessageReference": {
+            "type": "string",
+            "description": "The unique reference of the original balance query (IE034) message"
+        },
+        "response": {
+            "type": "object",
+            "description": "The response from the guarantee management system"
+        }
+    }
+}

--- a/public/api/definition.json
+++ b/public/api/definition.json
@@ -1,11 +1,4 @@
 {
-  "scopes": [
-    {
-      "key": "common-transit-convention-guarantee-balance-test-support",
-      "name": "Common Transit Convention Guarantee Balance Test Support",
-      "description": "Common Transit Convention Guarantee Balance Test Support API"
-    }
-  ],
   "api": {
     "name": "Common Transit Convention Guarantee Balance Test Support",
     "description": "The test support API to allow traders to trigger responses to Common Transit Convention guarantee balance enquiries",
@@ -17,7 +10,7 @@
         "status": "BETA",
         "endpointsEnabled": true,
         "access": {
-          "type": "PRIVATE"
+          "type": "PUBLIC"
         }
       }
     ]

--- a/public/api/definition.json
+++ b/public/api/definition.json
@@ -1,0 +1,25 @@
+{
+  "scopes": [
+    {
+      "key": "common-transit-convention-guarantee-balance-test-support",
+      "name": "Common Transit Convention Guarantee Balance Test Support",
+      "description": "Common Transit Convention Guarantee Balance Test Support API"
+    }
+  ],
+  "api": {
+    "name": "Common Transit Convention Guarantee Balance Test Support",
+    "description": "The test support API to allow traders to trigger responses to Common Transit Convention guarantee balance enquiries",
+    "context": "test/customs/guarantees",
+    "categories": ["CUSTOMS"],
+    "versions": [
+      {
+        "version": "1.0",
+        "status": "BETA",
+        "endpointsEnabled": true,
+        "access": {
+          "type": "PRIVATE"
+        }
+      }
+    ]
+  }
+}

--- a/test/controllers/TestMessagesControllerSpec.scala
+++ b/test/controllers/TestMessagesControllerSpec.scala
@@ -31,6 +31,9 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import play.api.http.HeaderNames
+import play.api.http.MimeTypes
+import play.api.libs.json.Json
 import play.api.test.FakeRequest
 import play.api.test.Helpers
 import play.api.test.Helpers._
@@ -69,21 +72,129 @@ class TestMessagesControllerSpec
 
   val messageRecipient = MessageIdRecipient("MDTP-GUA-22b9899e24ee48e6a18997d1")
 
-  val simulatedResponse = SimulatedResponse(
+  val simulatedJsonResponse = SimulatedResponse(
     TaxIdentifier("GB12345678900"),
     GuaranteeReference("05DE3300BE0001067A001017"),
     Some(UniqueReference("7acb933dbe7039")),
     BalanceRequestSuccess(BigDecimal("12345678.90"), CurrencyCode("GBP"))
   )
 
-  "TestMessagesController" should "pass through responses from trader router" in forAll(
+  val simulatedXmlResponse =
+    <CD037A>
+      <SynIdeMES1>UNOC</SynIdeMES1>
+      <SynVerNumMES2>3</SynVerNumMES2>
+      <MesSenMES3>NTA.GB</MesSenMES3>
+      <MesRecMES6>MDTP-GUA-22b9899e24ee48e6a18997d1</MesRecMES6>
+      <DatOfPreMES9>20210806</DatOfPreMES9>
+      <TimOfPreMES10>1505</TimOfPreMES10>
+      <IntConRefMES11>deadbeefcafeba</IntConRefMES11>
+      <MesIdeMES19>deadbeefcafeba</MesIdeMES19>
+      <MesTypMES20>GB037A</MesTypMES20>
+      <TRAPRIRC1>
+        <TINRC159>GB12345678900</TINRC159>
+      </TRAPRIRC1>
+      <CUSTOFFGUARNT>
+        <RefNumRNT1>GB000001</RefNumRNT1>
+      </CUSTOFFGUARNT>
+      <GUAREF2>
+        <GuaRefNumGRNREF21>21GB3300BE0001067A001017</GuaRefNumGRNREF21>
+        <AccDatREF24>20210114</AccDatREF24>
+        <GuaTypREF22>4</GuaTypREF22>
+        <GuaMonCodREF23>1</GuaMonCodREF23>
+        <GUAQUE>
+          <QueIdeQUE1>2</QueIdeQUE1>
+        </GUAQUE>
+        <EXPEXP>
+          <ExpEXP1>2751.95</ExpEXP1>
+          <ExpCouEXP2>2448</ExpCouEXP2>
+          <BalEXP3>1212211848.45</BalEXP3>
+          <CurEXP4>GBP</CurEXP4>
+        </EXPEXP>
+      </GUAREF2>
+    </CD037A>
+
+  "TestMessagesController" should "pass through responses from trader router for JSON requests" in forAll(
     responseCodes
   ) { responseCode =>
-    val request           = FakeRequest().withBody(simulatedResponse)
+    val request = FakeRequest()
+      .withHeaders(HeaderNames.CONTENT_TYPE -> MimeTypes.JSON)
+      .withBody(Json.stringify(Json.toJson(simulatedJsonResponse)))
+
     val connectorResponse = HttpResponse(responseCode, "")
     val controller        = mkController(injectMessageResponse = IO.pure(connectorResponse))
     val result            = controller.injectEisResponse(messageRecipient)(request)
+
     status(result) shouldBe responseCode
     contentAsString(result) shouldBe connectorResponse.body
+  }
+
+  it should "return a JSON parsing error for JSON requests that can't be parsed as a simulated response" in {
+    val request = FakeRequest()
+      .withHeaders(HeaderNames.CONTENT_TYPE -> MimeTypes.JSON)
+      .withBody("""{
+      |  "taxIdentifier": "GB12345678900",
+      |  "guaranteeReference": "21GB3300BE0001067A001017"
+      |}""".trim.stripMargin)
+
+    val controller = mkController()
+    val result     = controller.injectEisResponse(messageRecipient)(request)
+
+    status(result) shouldBe BAD_REQUEST
+    contentAsJson(result) shouldBe Json.obj(
+      "code"    -> "INVALID_REQUEST_JSON",
+      "message" -> "Invalid request JSON",
+      "errors"  -> Json.obj("$.response" -> Json.arr("error.path.missing"))
+    )
+  }
+
+  it should "return a bad request error for requests that can't be parsed as valid JSON" in {
+    val request = FakeRequest()
+      .withHeaders(HeaderNames.CONTENT_TYPE -> MimeTypes.JSON)
+      .withBody("""{
+      |  "taxIdentifier": "GB12345678900,
+      |  "guaranteeReference": "21GB3300BE0001067A001017"
+      |}""".trim.stripMargin)
+
+    val controller = mkController()
+    val result     = controller.injectEisResponse(messageRecipient)(request)
+
+    status(result) shouldBe BAD_REQUEST
+    contentAsString(result) should startWith("Invalid Json:")
+  }
+
+  it should "return a bad request error for requests that can't be parsed as valid XML" in {
+    val request = FakeRequest()
+      .withHeaders(HeaderNames.CONTENT_TYPE -> MimeTypes.XML)
+      .withBody("""<CD037A><CD037A>""".trim.stripMargin)
+
+    val controller = mkController()
+    val result     = controller.injectEisResponse(messageRecipient)(request)
+
+    status(result) shouldBe BAD_REQUEST
+    contentAsString(result) should startWith("Invalid XML:")
+  }
+
+  it should "pass through responses from trader router for XML requests" in forAll(
+    responseCodes
+  ) { responseCode =>
+    val request = FakeRequest()
+      .withHeaders(HeaderNames.CONTENT_TYPE -> MimeTypes.XML)
+      .withBody(simulatedXmlResponse.toString)
+
+    val connectorResponse = HttpResponse(responseCode, "")
+    val controller        = mkController(injectMessageResponse = IO.pure(connectorResponse))
+    val result            = controller.injectEisResponse(messageRecipient)(request)
+
+    status(result) shouldBe responseCode
+    contentAsString(result) shouldBe connectorResponse.body
+  }
+
+  it should "reject unsupported media types" in {
+    val request = FakeRequest().withBody("")
+
+    val controller = mkController()
+    val result     = controller.injectEisResponse(messageRecipient)(request)
+
+    status(result) shouldBe UNSUPPORTED_MEDIA_TYPE
   }
 }

--- a/test/controllers/documentation/DocumentationRoutesSpec.scala
+++ b/test/controllers/documentation/DocumentationRoutesSpec.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.documentation
+
+import akka.stream.Materializer
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.mvc.Call
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+
+class DocumentationRoutesSpec extends AnyFlatSpec with Matchers with GuiceOneAppPerSuite {
+
+  implicit val materializer = app.injector.instanceOf[Materializer]
+
+  "API documentation route" should "return 200 and JSON response for definition.json" in {
+    val request = FakeRequest(Call("GET", "/api/definition"))
+    val result  = route(app, request).get
+
+    status(result) shouldBe OK
+    contentType(result) should contain(JSON)
+
+    val definitionJson = contentAsJson(result)
+    val scopeKey       = (definitionJson \ "scopes" \\ "key").head.as[String]
+    val apiContext     = (definitionJson \ "api" \ "context").as[String]
+
+    scopeKey shouldBe "common-transit-convention-guarantee-balance-test-support"
+    apiContext shouldBe "test/customs/guarantees"
+  }
+
+  it should "return 200 and plain text response for the RAML definition file" in {
+    val request = FakeRequest(Call("GET", "/api/conf/1.0/application.raml"))
+    val result  = route(app, request).get
+    status(result) shouldBe OK
+    contentType(result) should contain(BINARY)
+  }
+
+  it should "return 200 and plain text response for the overview Markdown file" in {
+    val request = FakeRequest(Call("GET", "/api/conf/1.0/docs/overview.md"))
+    val result  = route(app, request).get
+    status(result) shouldBe OK
+    contentType(result) should contain(BINARY)
+  }
+
+  it should "return 404 for nonexistent resource" in {
+    val request = FakeRequest(Call("GET", "/api/conf/1.0/docs/foobar.md"))
+    val result  = route(app, request).get
+    status(result) shouldBe NOT_FOUND
+  }
+}

--- a/test/controllers/documentation/DocumentationRoutesSpec.scala
+++ b/test/controllers/documentation/DocumentationRoutesSpec.scala
@@ -36,10 +36,8 @@ class DocumentationRoutesSpec extends AnyFlatSpec with Matchers with GuiceOneApp
     contentType(result) should contain(JSON)
 
     val definitionJson = contentAsJson(result)
-    val scopeKey       = (definitionJson \ "scopes" \\ "key").head.as[String]
     val apiContext     = (definitionJson \ "api" \ "context").as[String]
 
-    scopeKey shouldBe "common-transit-convention-guarantee-balance-test-support"
     apiContext shouldBe "test/customs/guarantees"
   }
 


### PR DESCRIPTION
This implements a basic RAML definition for the Guarantee Balance Test Support API.

It's needed so that we can get the Postman test suite working on QA and staging, as they will need to call this API in order to trigger simulated responses in the asynchronous response part of the test suite.

This also enables exact XML messages to be triggered for testing of invalid responses (i.e. responses that are not schema-valid).